### PR TITLE
Link static libraries in all wheels

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -40,13 +40,10 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: >
             LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
-            CFLAGS="-ffunction-sections -fdata-sections"
-            LDFLAGS="-Wl,--gc-sections"
           CIBW_ENVIRONMENT_MACOS: >
             LIBTOOLIZE=glibtoolize
             DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
-            LDFLAGS="-dead_strip"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_TEST_SKIP: "*_arm64"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -38,12 +38,12 @@ jobs:
           CIBW_BEFORE_ALL: bash {project}/scripts/build_third_party.sh
           CIBW_BEFORE_BUILD: git clean -xf && rm -rf {project}/build
           CIBW_ENVIRONMENT_LINUX: >
-            LD_LIBRARY_PATH=/tmp/build/lib:$LD_LIBRARY_PATH
-            PKG_CONFIG_PATH=/tmp/build/lib/pkgconfig:$PKG_CONFIG_PATH
+            LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+            PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
           CIBW_ENVIRONMENT_MACOS: >
             LIBTOOLIZE=glibtoolize
-            DYLD_LIBRARY_PATH=/tmp/build/lib:$DYLD_LIBRARY_PATH
-            PKG_CONFIG_PATH=/tmp/build/lib/pkgconfig:$PKG_CONFIG_PATH
+            DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
+            PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_TEST_SKIP: "*_arm64"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -38,12 +38,12 @@ jobs:
           CIBW_BEFORE_ALL: bash {project}/scripts/build_third_party.sh
           CIBW_BEFORE_BUILD: git clean -xf && rm -rf {project}/build
           CIBW_ENVIRONMENT_LINUX: >
-            LD_LIBRARY_PATH=/opt/local/lib:$LD_LIBRARY_PATH
-            PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH
+            LD_LIBRARY_PATH=/tmp/build/lib:$LD_LIBRARY_PATH
+            PKG_CONFIG_PATH=/tmp/build/lib/pkgconfig:$PKG_CONFIG_PATH
           CIBW_ENVIRONMENT_MACOS: >
             LIBTOOLIZE=glibtoolize
-            DYLD_LIBRARY_PATH=/opt/local/lib:$DYLD_LIBRARY_PATH
-            PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH
+            DYLD_LIBRARY_PATH=/tmp/build/lib:$DYLD_LIBRARY_PATH
+            PKG_CONFIG_PATH=/tmp/build/lib/pkgconfig:$PKG_CONFIG_PATH
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_TEST_SKIP: "*_arm64"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,7 +33,7 @@ jobs:
         run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_ARCHS_MACOS: x86_64
+          CIBW_ARCHS_MACOS: arm64 x86_64
           CIBW_SKIP: cp36* cp37* pp* cp38-macos*
           CIBW_BEFORE_ALL: bash {project}/scripts/build_third_party.sh
           CIBW_BEFORE_BUILD: git clean -xf && rm -rf {project}/build
@@ -46,10 +46,11 @@ jobs:
             LIBTOOLIZE=glibtoolize
             DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
-            LDFLAGS="-dead_strip"
+            CFLAGS=$ARCHFLAGS
+            LDFLAGS="$ARCHFLAGS -dead_strip"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
-          CIBW_TEST_SKIP: "*_arm64"
+          CIBW_TEST_SKIP: "*_arm64 *_aarch64"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_MACOS: x86_64
           CIBW_SKIP: cp36* cp37* pp* cp38-macos*
           CIBW_BEFORE_ALL: bash {project}/scripts/build_third_party.sh

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -35,13 +35,15 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_ARCHS_MACOS: x86_64
           CIBW_SKIP: cp36* cp37* pp* cp38-macos*
-          CIBW_BEFORE_ALL_LINUX: bash {project}/scripts/build_third_party.sh
+          CIBW_BEFORE_ALL: bash {project}/scripts/build_third_party.sh
           CIBW_BEFORE_BUILD: git clean -xf && rm -rf {project}/build
           CIBW_ENVIRONMENT_LINUX: >
-            LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-            PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
+            LD_LIBRARY_PATH=/opt/local/lib:$LD_LIBRARY_PATH
+            PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH
           CIBW_ENVIRONMENT_MACOS: >
             LIBTOOLIZE=glibtoolize
+            DYLD_LIBRARY_PATH=/opt/local/lib:$DYLD_LIBRARY_PATH
+            PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_TEST_SKIP: "*_arm64"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -40,10 +40,13 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: >
             LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+            CFLAGS="-ffunction-sections -fdata-sections"
+            LDFLAGS="-Wl,--gc-sections"
           CIBW_ENVIRONMENT_MACOS: >
             LIBTOOLIZE=glibtoolize
             DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+            LDFLAGS="-dead_strip"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_TEST_SKIP: "*_arm64"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,7 +33,7 @@ jobs:
         run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_ARCHS_MACOS: arm64 x86_64
+          CIBW_ARCHS_MACOS: x86_64
           CIBW_SKIP: cp36* cp37* pp* cp38-macos*
           CIBW_BEFORE_ALL: bash {project}/scripts/build_third_party.sh
           CIBW_BEFORE_BUILD: git clean -xf && rm -rf {project}/build
@@ -46,8 +46,7 @@ jobs:
             LIBTOOLIZE=glibtoolize
             DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
-            CFLAGS=$ARCHFLAGS
-            LDFLAGS="$ARCHFLAGS -dead_strip"
+            LDFLAGS="-dead_strip"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_TEST_SKIP: "*_arm64 *_aarch64"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_ARCHS_MACOS: x86_64
           CIBW_SKIP: cp36* cp37* pp* cp38-macos*
           CIBW_BEFORE_ALL_LINUX: bash {project}/scripts/build_third_party.sh
@@ -44,6 +44,7 @@ jobs:
             LIBTOOLIZE=glibtoolize
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
+          CIBW_TEST_SKIP: "*_arm64"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/build.py
+++ b/build.py
@@ -6,7 +6,7 @@ ext_modules = [
     Extension(
         "fontconfig.fontconfig",
         sources=["src/fontconfig/fontconfig.pyx"],
-        libraries=["fontconfig"],
+        libraries=["fontconfig", "freetype"],
     ),
 ]
 

--- a/build.py
+++ b/build.py
@@ -6,7 +6,7 @@ ext_modules = [
     Extension(
         "fontconfig.fontconfig",
         sources=["src/fontconfig/fontconfig.pyx"],
-        libraries=["fontconfig", "freetype", "expat"],
+        libraries=["fontconfig"],
     ),
 ]
 

--- a/build.py
+++ b/build.py
@@ -6,7 +6,7 @@ ext_modules = [
     Extension(
         "fontconfig.fontconfig",
         sources=["src/fontconfig/fontconfig.pyx"],
-        libraries=["fontconfig", "freetype"],
+        libraries=["fontconfig", "freetype", "expat"],
     ),
 ]
 

--- a/build.py
+++ b/build.py
@@ -6,7 +6,7 @@ ext_modules = [
     Extension(
         "fontconfig.fontconfig",
         sources=["src/fontconfig/fontconfig.pyx"],
-        libraries=["fontconfig", "freetype", "expat", "z"],
+        libraries=["fontconfig", "freetype", "expat", "z", "bz2"],
     ),
 ]
 

--- a/build.py
+++ b/build.py
@@ -6,7 +6,7 @@ ext_modules = [
     Extension(
         "fontconfig.fontconfig",
         sources=["src/fontconfig/fontconfig.pyx"],
-        libraries=["fontconfig", "freetype", "expat", "z", "bz2"],
+        libraries=["fontconfig", "freetype", "expat", "z"],
     ),
 ]
 

--- a/build.py
+++ b/build.py
@@ -6,7 +6,7 @@ ext_modules = [
     Extension(
         "fontconfig.fontconfig",
         sources=["src/fontconfig/fontconfig.pyx"],
-        libraries=["fontconfig"],
+        libraries=["fontconfig", "freetype", "expat", "z"],
     ),
 ]
 

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -2,10 +2,18 @@
 
 set -ex
 
+# Set up cross-compilation on macOS.
+HOST_ARCH=${HOST_ARCH:-$(gcc -dumpmachine)}
+if [[ $OSTYPE == "darwin"* ]] && [[ "$_PYTHON_HOST_PLATFORM" == *"arm64" ]]; then
+    HOST_ARCH="arm64-apple-darwin"
+fi
+
+
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
     ./configure \
+        --host=$HOST_ARCH \
         --disable-shared \
         --with-pic \
         --without-bzip2 \
@@ -21,6 +29,7 @@ build_freetype() {
 build_fontconfig() {
     cd third_party/fontconfig
     ./autogen.sh \
+        --host=$HOST_ARCH \
         --disable-shared \
         --with-pic \
         --disable-nls \

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -5,7 +5,7 @@ set -eux
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure --prefix=/opt/local
+    ./configure --prefix=/tmp/build
     make
     make -j
     make install
@@ -14,7 +14,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh --prefix=/opt/local
+    ./autogen.sh --prefix=/tmp/build
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -2,10 +2,12 @@
 
 set -ex
 
+export CFLAGS="$CFLAGS -fPIC"
+
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure --without-png --without-harfbuzz --without-brotli --without-librsvg
+    ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
     make -j
     make install
     cd ../..
@@ -13,7 +15,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh --disable-libxml2 --disable-iconv --disable-nls
+    ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -5,7 +5,7 @@ set -eux
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure --static --without-png --without-harfbuzz --without-brotli --without-librsvg
+    ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
     make
     make -j
     make install
@@ -14,7 +14,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh --static --disable-libxml2 --disable-iconv --disable-nls
+    ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -5,7 +5,7 @@ set -eux
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure
+    ./configure --prefix=/opt/local
     make
     make -j
     make install
@@ -14,7 +14,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh
+    ./autogen.sh --prefix=/opt/local
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -2,18 +2,10 @@
 
 set -ex
 
-# Set up cross-compilation on macOS.
-HOST_ARCH=${HOST_ARCH:-$(gcc -dumpmachine)}
-if [[ $OSTYPE == "darwin"* ]] && [[ "$_PYTHON_HOST_PLATFORM" == *"arm64" ]]; then
-    HOST_ARCH="arm64-apple-darwin"
-fi
-
-
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
     ./configure \
-        --host=$HOST_ARCH \
         --disable-shared \
         --with-pic \
         --without-bzip2 \
@@ -29,7 +21,6 @@ build_freetype() {
 build_fontconfig() {
     cd third_party/fontconfig
     ./autogen.sh \
-        --host=$HOST_ARCH \
         --disable-shared \
         --with-pic \
         --disable-nls \

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -5,7 +5,7 @@ set -eux
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure
+    ./configure --static --without-png --without-harfbuzz --without-brotli --without-librsvg
     make
     make -j
     make install
@@ -14,7 +14,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh
+    ./autogen.sh --static --disable-libxml2 --disable-iconv --disable-nls
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -ex
 
 export CFLAGS="$CFLAGS -fPIC"
 

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -5,7 +5,7 @@ set -eux
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    LDFLAGS=-fPIC ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
+    CFLAGS=-fPIC ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
     make
     make -j
     make install
@@ -14,7 +14,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    LDFLAGS=-fPIC ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
+    CFLAGS=-fPIC ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -2,11 +2,12 @@
 
 set -eux
 
+export CFLAGS="$CFLAGS -fPIC"
+
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    CFLAGS=-fPIC ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
-    make
+    ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
     make -j
     make install
     cd ../..
@@ -14,7 +15,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    CFLAGS=-fPIC ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
+    ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -5,7 +5,7 @@ set -eux
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
+    LDFLAGS=-fPIC ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
     make
     make -j
     make install
@@ -14,7 +14,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
+    LDFLAGS=-fPIC ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -5,7 +5,7 @@ set -eux
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure --prefix=/tmp/build
+    ./configure
     make
     make -j
     make install
@@ -14,7 +14,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh --prefix=/tmp/build
+    ./autogen.sh
     make -j
     make install
     cd ../..
@@ -22,7 +22,7 @@ build_fontconfig() {
 
 # Install build dependencies
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    # TODO: This will conflict with brew-installed freetype and fontconfig
+    brew uninstall --ignore-dependencies -f fontconfig freetype
     brew install gperftools gettext automake
 elif command -v yum &> /dev/null; then
     yum --disablerepo=epel install -y gperf gettext-devel libuuid-devel

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -2,12 +2,10 @@
 
 set -ex
 
-export CFLAGS="$CFLAGS -fPIC"
-
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
+    ./configure --without-png --without-harfbuzz --without-brotli --without-librsvg
     make -j
     make install
     cd ../..
@@ -15,7 +13,7 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
+    ./autogen.sh --disable-libxml2 --disable-iconv --disable-nls
     make -j
     make install
     cd ../..

--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -2,12 +2,17 @@
 
 set -ex
 
-export CFLAGS="$CFLAGS -fPIC"
-
 build_freetype() {
     cd third_party/freetype
     ./autogen.sh
-    ./configure --disable-shared --without-png --without-harfbuzz --without-brotli --without-librsvg
+    ./configure \
+        --disable-shared \
+        --with-pic \
+        --without-bzip2 \
+        --without-png \
+        --without-harfbuzz \
+        --without-brotli \
+        --without-librsvg
     make -j
     make install
     cd ../..
@@ -15,7 +20,14 @@ build_freetype() {
 
 build_fontconfig() {
     cd third_party/fontconfig
-    ./autogen.sh --disable-shared --disable-libxml2 --disable-iconv --disable-nls
+    ./autogen.sh \
+        --disable-shared \
+        --with-pic \
+        --disable-nls \
+        --disable-libxml2 \
+        --disable-iconv \
+        --disable-docs \
+        --disable-cache-build
     make -j
     make install
     cd ../..


### PR DESCRIPTION
This PR replaces bundled dynamic libraries with static linking.

This also prepares for cross-compiling on macOS, though, there seem to be several issues with building arm64 wheels on macOS at the moment.
https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile