### PR TITLE
Fix memory leaks around FcValue conversion

### DIFF
--- a/tests/test_fontconfig.py
+++ b/tests/test_fontconfig.py
@@ -87,11 +87,11 @@ def test_Pattern_subset(pattern: fontconfig.Pattern) -> None:
 @pytest.mark.parametrize(
     "key, value",
     [
-        ("family", b"Arial"),
+        ("family", "Arial"),
         ("slant", 80),
         ("aspect", 1.0),
         ("antialias", True),
-        ("lang", [b"en"]),
+        ("lang", ["en"]),
         ("size", (10.0, 10.0)),
     ],
 )


### PR DESCRIPTION
Changes:
- Call `FcValueDestroy` in `Pattern.add` to release memory
- Change the arrow operator from `[0].` to `.`
- Use `str` as a default type for string values