### PR TITLE
Add indexing operators to ObjectSet and FontSet

### DIFF
--- a/src/fontconfig/fontconfig.pyx
+++ b/src/fontconfig/fontconfig.pyx
@@ -2,7 +2,6 @@ import atexit
 import logging
 from typing import Any, Dict, Iterable, Iterator, List, Tuple
 
-from cython.cimports.libc.stdlib import free
 cimport fontconfig._fontconfig as c_impl
 
 
@@ -513,7 +512,7 @@ cdef class Pattern:
         if result is NULL:
             raise ValueError("Invalid format: %s" % fmt)
         py_str = <bytes>(result).decode("utf-8")
-        free(result)
+        c_impl.FcStrFree(result)
         return py_str
 
     def __repr__(self) -> str:

--- a/src/fontconfig/fontconfig.pyx
+++ b/src/fontconfig/fontconfig.pyx
@@ -238,10 +238,9 @@ cdef class Config:
     def font_sort(self, p: Pattern, trim: bool) -> Optional[FontSet]:
         """Return list of matching fonts"""
         cdef c_impl.FcResult result
-        cdef c_impl.FcCharSet* csp = NULL
         cdef c_impl.FcFontSet* ptr = c_impl.FcFontSort(
-            self._ptr, p._ptr, <c_impl.FcBool>trim, &csp, &result)
-        # TODO: Return csp
+            self._ptr, p._ptr, <c_impl.FcBool>trim, NULL, &result)
+        # TODO: Support csp
         if result == c_impl.FcResultMatch:
             return FontSet(<intptr_t>ptr)
         elif result == c_impl.FcResultNoMatch:

--- a/tests/test_fontconfig.py
+++ b/tests/test_fontconfig.py
@@ -247,10 +247,6 @@ def test_Pattern_remove() -> None:
     assert isinstance(pattern.remove("aspect", 0), bool)
 
 
-def test_Pattern_iter(pattern: fontconfig.Pattern) -> None:
-    dict(pattern)
-
-
 def test_Pattern_unparse(pattern: fontconfig.Pattern) -> None:
     assert isinstance(pattern.unparse(), str)
 
@@ -263,11 +259,38 @@ def test_Pattern_default_format(pattern: fontconfig.Pattern) -> None:
     assert isinstance(pattern.format("%{lang}"), str)
 
 
+def test_Pattern_iter(pattern: fontconfig.Pattern) -> None:
+    dict(pattern)
+
+
+def test_Pattern_repr(pattern) -> None:
+    repr(pattern)
+
+
 @pytest.fixture
 def object_set():
     object_set = fontconfig.ObjectSet.create()
     object_set.build(["family", "style", "slant", "weight", "size", "aspect", "lang"])
     yield object_set
+
+
+def test_ObjectSet_add(object_set) -> None:
+    assert isinstance(object_set.add("familylang"), bool)
+
+
+def test_ObjectSet_iter(object_set) -> None:
+    for item in object_set:
+        assert isinstance(item, str)
+
+
+def test_ObjectSet_getitem(object_set) -> None:
+    for i in range(len(object_set)):
+        assert isinstance(object_set[i], str)
+    assert isinstance(object_set[-1], str)
+
+
+def test_ObjectSet_repr(object_set) -> None:
+    repr(object_set)
 
 
 def test_query() -> None:


### PR DESCRIPTION
Changes
- Add type checking in `ObjectSet.add`
- Add `getitem` and `len` operators to ObjectSet and FontSet
- Add `repr` methods to iterable objects