### PR TITLE
Add missing apt package in readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - libfontconfig-dev
   jobs:
     post_create_environment:
       - pip install poetry


### PR DESCRIPTION
Changes:
- Add `libfontconfig-dev` in apt packages