### PR TITLE
Add build dependency in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,13 +4,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  apt_packages:
-    - libfontconfig-dev
   jobs:
     post_create_environment:
       - pip install poetry
       - poetry config virtualenvs.create false
     post_install:
+      - apt-get -yq remove libfontconfig-dev
+      - bash scripts/build_third_party.sh
       - poetry install --with docs
 
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
       - pip install poetry
       - poetry config virtualenvs.create false
     post_install:
-      - apt-get -yq remove libfontconfig-dev
+      - sudo apt-get -yq remove libfontconfig-dev
       - bash scripts/build_third_party.sh
       - poetry install --with docs
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,13 +4,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - libfontconfig-dev
   jobs:
     post_create_environment:
       - pip install poetry
       - poetry config virtualenvs.create false
     post_install:
-      - sudo apt-get -yq remove libfontconfig-dev
-      - bash scripts/build_third_party.sh
       - poetry install --with docs
 
 sphinx:

--- a/src/fontconfig/fontconfig.pyx
+++ b/src/fontconfig/fontconfig.pyx
@@ -266,6 +266,7 @@ cdef class Config:
             raise MemoryError()
         return FontSet(<intptr_t>ptr)
 
+    '''
     def get_filename(self, name: str = "") -> str:
         """Find a config file"""
         cdef bytes filename
@@ -273,6 +274,7 @@ cdef class Config:
         filename = <bytes>c_impl.FcConfigGetFilename(
             self._ptr, <const c_impl.FcChar8*>name_)
         return filename.decode("utf-8")
+    '''
 
     def parse_and_load(self, filename: str, complain: bool = True) -> bool:
         """Load a configuration file"""

--- a/tests/test_fontconfig.py
+++ b/tests/test_fontconfig.py
@@ -135,6 +135,7 @@ def test_Config_font_list(config, pattern, object_set) -> None:
     assert isinstance(fonts, fontconfig.FontSet)
 
 
+@pytest.mark.skip(reason="version compatibility issue")
 def test_Config_get_filename(config) -> None:
     assert isinstance(config.get_filename(), str)
 


### PR DESCRIPTION
Changes:
- Disable `Config.get_filename` due to version incompatibility with readthedocs environment