### PR TITLE
Fix fontconfig build paths and add Homebrew check

### DIFF
--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -21,6 +21,8 @@ build_freetype() {
 build_fontconfig() {
     cd third_party/fontconfig
     ./autogen.sh \
+        --sysconfdir=${FC_SYSCONFDIR:-"/etc"} \
+        --localstatedir=${FC_LOCALSTATEDIR:-"/var"} \
         --disable-shared \
         --with-pic \
         --disable-libxml2 \
@@ -46,9 +48,20 @@ prepare_macos_dirs() {
 
 # Install build dependencies
 if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Check for Homebrew
+    if ! command -v brew &> /dev/null; then
+        echo "Error: Homebrew is required for macOS builds" >&2
+        echo "Install Homebrew from https://brew.sh" >&2
+        exit 1
+    fi
+
     export CFLAGS="$CFLAGS -arch x86_64 -arch arm64"
     export LDFLAGS="$LDFLAGS -arch x86_64 -arch arm64"
     export LIBTOOLIZE="glibtoolize"
+    # Set Homebrew-specific directories for fontconfig by default on macOS
+    export FC_SYSCONFDIR="$(brew --prefix)/etc"
+    export FC_LOCALSTATEDIR="$(brew --prefix)/var"
+    # Make sure conflicting packages are not installed
     brew uninstall --ignore-dependencies -f fontconfig freetype
     brew install gperftools gettext automake libtool
     prepare_macos_dirs


### PR DESCRIPTION
## Summary

- Add missing `--sysconfdir` and `--localstatedir` configure options to fontconfig build
- Add Homebrew requirement check for macOS builds
- Set platform-specific paths for configuration and cache directories

## Problem

The fontconfig build was missing critical path configuration options (`--sysconfdir` and `--localstatedir`), resulting in empty or incorrect build-time paths. This could cause runtime issues when fontconfig tries to locate:
- Configuration files (typically in `/etc/fonts/` or `$(brew --prefix)/etc/fonts/`)
- Font cache directories (typically in `/var/cache/fontconfig/` or `$(brew --prefix)/var/cache/fontconfig/`)

## Changes

1. **Configure options added:**
   - `--sysconfdir=${FC_SYSCONFDIR:-"/etc"}` - Sets system configuration directory
   - `--localstatedir=${FC_LOCALSTATEDIR:-"/var"}` - Sets variable state directory

2. **Platform-specific paths:**
   - **Linux**: Uses standard FHS paths (`/etc` and `/var`)
   - **macOS**: Uses Homebrew-managed paths (`$(brew --prefix)/etc` and `$(brew --prefix)/var`)

3. **Build validation:**
   - Added check to ensure Homebrew is installed before macOS builds
   - Provides helpful error message with installation instructions if missing

## Test plan

- [x] Verify Linux wheel builds succeed in CI
- [x] Verify macOS wheel builds succeed in CI
- [ ] Test that fontconfig can locate configuration files at runtime
- [ ] Verify the build fails gracefully on macOS without Homebrew

🤖 Generated with [Claude Code](https://claude.com/claude-code)