### PR TITLE
Fix _FcSetName enum import warning

### DIFF
--- a/src/fontconfig/_fontconfig.pxd
+++ b/src/fontconfig/_fontconfig.pxd
@@ -135,7 +135,7 @@ cdef extern from "fontconfig/fontconfig.h":
 
     ctypedef _FcLangResult FcLangResult
 
-    cpdef enum _FcSetName:
+    cdef enum _FcSetName:
         FcSetSystem
         FcSetApplication
 


### PR DESCRIPTION
## Summary

Fixes the warning that appears during tests:
```
UserWarning: enum class _FcSetName not importable from fontconfig._fontconfig. 
You are probably using a cpdef enum declared in a .pxd file that does not have a .py or .pyx file.
```

## Changes

- Changed `cpdef enum _FcSetName` to `cdef enum _FcSetName` in `_fontconfig.pxd`

## Rationale

The `_FcSetName` enum is only used internally in the C API and doesn't need to be exposed to Python. The Python wrapper in `fontconfig.pyx` already handles the string-to-enum mapping in the `get_fonts()` method (lines 164-181).

Using `cpdef enum` in a `.pxd` file without a corresponding `.pyx` file that exports it causes Cython to attempt making the enum importable from Python, but since there's no implementation file defining it, Python can't find it and generates the warning.

## Test plan

- [x] All existing tests pass without warnings
- [x] Specifically tested `test_Config_get_fonts[system]` and `test_Config_get_fonts[application]` which previously showed the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)