### PR TITLE
Implement single-source versioning from __init__.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,13 +3,15 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import fontconfig
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "fontconfig-py"
 copyright = "2023, Kota Yamaguchi"
 author = "Kota Yamaguchi"
-release = "0.1.3"
+release = fontconfig.__version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fontconfig-py"
-version = "0.3.0"
+dynamic = ["version"]
 description = "Python bindings to fontconfig"
 authors = [
     {name = "Kota Yamaguchi", email = "yamaguchi_kota@cyberagent.co.jp"}
@@ -17,6 +17,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["fontconfig*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "fontconfig.__version__"}
 
 [tool.setuptools.package-data]
 fontconfig = ["py.typed", "*.pyi"]

--- a/uv.lock
+++ b/uv.lock
@@ -157,7 +157,6 @@ wheels = [
 
 [[package]]
 name = "fontconfig-py"
-version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

This PR implements single-source versioning where the version number is defined only in `src/fontconfig/__init__.py` and automatically synced to both the package build and documentation.

## Changes

- **pyproject.toml**: Added `dynamic = ["version"]` and `[tool.setuptools.dynamic]` configuration to read version from `fontconfig.__version__`
- **docs/source/conf.py**: Updated to import `fontconfig` package and read version dynamically instead of hardcoded `"0.1.3"`
- **uv.lock**: Updated to reflect the dynamic versioning change

## Benefits

- ✅ Version only needs to be updated in one place (`__init__.py`)
- ✅ Eliminates version sync issues between code, package metadata, and documentation
- ✅ Follows Python packaging best practices for single-source versioning
- ✅ Automatically keeps docs version in sync with package version

## Test Plan

- [x] Package builds successfully with `uv sync`
- [x] Version is correctly read: `python -c "import fontconfig; print(fontconfig.__version__)"` → `0.3.0`
- [x] Sphinx docs configuration reads version correctly
- [x] Verify docs build with correct version number

## Related Issues

Resolves the issue where `docs/source/conf.py` had an outdated version (`0.1.3`) while the actual package version was `0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)