### PR TITLE
Add automated release tooling

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,52 @@
+Execute the release workflow for fontconfig-py. Follow every step below in order.
+
+## Step 1 — Read current version
+
+Read `src/fontconfig/__init__.py` and extract `__version__`.
+
+## Step 2 — Validate CHANGELOG
+
+Read `CHANGELOG.md`. Find the `## [Unreleased]` section (everything between that heading and the next `## [` heading). If it contains no bullet points (`- `), stop and tell the user:
+
+> The `[Unreleased]` section in CHANGELOG.md is empty. Please add entries describing what changed before running a release.
+
+## Step 3 — Determine the target version
+
+**If `$ARGUMENTS` is provided:** trim any surrounding whitespace. If it does not match `v\d+\.\d+\.\d+`, tell the user the format must be `vX.Y.Z` and stop.
+
+**If `$ARGUMENTS` is empty:** infer the next version from the `[Unreleased]` section headings and the current version:
+
+- Any `### Breaking Changes` heading → **major** bump (`X+1.0.0`)
+- Any `### Added` heading (no breaking changes) → **minor** bump (`x.Y+1.0`)
+- Any `### Changed` heading with no `Added` or `Breaking Changes` → **ambiguous** — tell the user "Changed entries could indicate a minor or patch release" and ask them to confirm which bump type to use before proceeding.
+- Only `### Fixed`, `### Documentation`, `### Infrastructure`, or `### Technical` headings → **patch** bump (`x.y.Z+1`)
+
+Present the suggested version (e.g. "Suggested version: **v1.0.2** (patch bump)") and ask the user to confirm with a simple yes/no or an alternative version before continuing.
+
+## Step 4 — Run the release script
+
+Once the version is confirmed, run:
+
+```bash
+bash scripts/release.sh <VERSION>
+```
+
+Capture stdout and stderr. If the script exits non-zero, surface the error message and offer remediation advice:
+
+- `branch release/<VERSION> already exists` → delete the branch with `git branch -d release/<VERSION>` and retry, or choose a different version.
+- `tag v<VERSION> already exists` → choose a different version.
+- `already present in CHANGELOG` → choose a different version.
+- Any other error → show the raw error and suggest the user investigate.
+
+## Step 5 — Report success
+
+On a zero exit, extract the pull request URL from the script output (look for a line containing `https://github.com/`) and display it prominently.
+
+Then summarise next steps:
+
+1. **Wait for CI checks** to pass on the PR (wheels build + tests on 3 platforms).
+2. **Review and merge the PR** via GitHub — never commit directly to `main`.
+3. **Auto-release fires automatically** after merge: `auto-release.yaml` creates the git tag and GitHub Release.
+4. **Wheels are built and published** by `wheels.yaml` triggered by the GitHub Release.
+5. **Manual approval required:** the `release` environment in GitHub Actions gates the PyPI upload — watch for an approval request in the Actions UI and approve it.
+6. **Verify publication** once complete: `pip index versions fontconfig-py`

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -6,13 +6,13 @@ Read `src/fontconfig/__init__.py` and extract `__version__`.
 
 ## Step 2 — Validate CHANGELOG
 
-Read `CHANGELOG.md`. Find the `## [Unreleased]` section (everything between that heading and the next `## [` heading). If it contains no bullet points (`- `), stop and tell the user:
+Read `CHANGELOG.md`. Find the `## [Unreleased]` section (everything between that heading and the next `## [` heading). If it contains no non-whitespace content, stop and tell the user:
 
-> The `[Unreleased]` section in CHANGELOG.md is empty. Please add entries describing what changed before running a release.
+> The `[Unreleased]` section in CHANGELOG.md is empty. Please add content describing what changed before running a release.
 
 ## Step 3 — Determine the target version
 
-**If `$ARGUMENTS` is provided:** trim any surrounding whitespace. If it does not match `v\d+\.\d+\.\d+`, tell the user the format must be `vX.Y.Z` and stop.
+**If `$ARGUMENTS` is provided:** trim any surrounding whitespace. If it does not match `(?:v)?\d+\.\d+\.\d+`, tell the user the format must be `X.Y.Z` or `vX.Y.Z` and stop.
 
 **If `$ARGUMENTS` is empty:** infer the next version from the `[Unreleased]` section headings and the current version:
 
@@ -33,7 +33,7 @@ bash scripts/release.sh <VERSION>
 
 Capture stdout and stderr. If the script exits non-zero, surface the error message and offer remediation advice:
 
-- `branch release/<VERSION> already exists` → delete the branch with `git branch -d release/<VERSION>` and retry, or choose a different version.
+- `branch release/v<VERSION> already exists` → delete the branch with `git branch -d release/v<VERSION>` and retry, or choose a different version.
 - `tag v<VERSION> already exists` → choose a different version.
 - `already present in CHANGELOG` → choose a different version.
 - Any other error → show the raw error and suggest the user investigate.

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,0 +1,112 @@
+name: Auto Release
+
+# Triggers when a release/v* branch is merged into main.
+# Creates the git tag and GitHub Release, which in turn triggers
+# the wheels.yaml workflow to build and publish to PyPI.
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: Create tag and GitHub Release
+    runs-on: ubuntu-latest
+    # Only run when a release branch is actually merged (not just closed/abandoned)
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Check out the merge commit on main (default for pull_request events)
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Extract version from __init__.py
+        id: version
+        run: |
+          VERSION=$(python3 -c "
+          import re
+          m = re.search(r'__version__ = \"([^\"]+)\"', open('src/fontconfig/__init__.py').read())
+          if not m:
+              raise SystemExit('__version__ not found in src/fontconfig/__init__.py')
+          print(m.group(1))
+          ")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Check if tag already exists
+        id: tag_check
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --exit-code origin "refs/tags/$TAG" > /dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping release creation."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog notes for this version
+        if: steps.tag_check.outputs.exists == 'false'
+        id: changelog
+        run: |
+          NOTES_FILE=$(mktemp)
+          python3 - "${{ steps.version.outputs.version }}" "$NOTES_FILE" <<'PYEOF'
+          import re, sys
+
+          version, out_path = sys.argv[1], sys.argv[2]
+          with open("CHANGELOG.md") as f:
+              content = f.read()
+
+          # Match the versioned section body (between this heading and the next)
+          pattern = re.compile(
+              r"## \[" + re.escape(version) + r"\][^\n]*\n"
+              r"(.*?)"
+              r"(?=^## \[|\Z)",
+              re.DOTALL | re.MULTILINE,
+          )
+          m = pattern.search(content)
+          if not m:
+              print(f"Warning: no CHANGELOG section found for [{version}]", file=sys.stderr)
+              body = f"Release {version}"
+          else:
+              body = m.group(1).strip()
+
+          with open(out_path, "w") as f:
+              f.write(body + "\n")
+
+          print(f"Extracted {len(body)} characters of release notes")
+          PYEOF
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed tag $TAG"
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "Release ${{ steps.version.outputs.version }}" \
+            --notes-file "${{ steps.changelog.outputs.notes_file }}"
+          echo "GitHub Release created for ${{ steps.version.outputs.tag }}"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
   "MD013": false,
+  "MD024": { "allow_different_nesting": true },
   "MD041": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.0.1] - 2025-12-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Infrastructure
+
+- Add automated release script (`scripts/release.sh`) and GitHub Actions workflow (`auto-release.yaml`) to streamline the release process (#68)
+
 ## [1.0.1] - 2025-12-23
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,81 +299,36 @@ matched = config.font_match(pattern)
 
 ## Release Process
 
-The project uses a **pull request-based release workflow** to ensure code review before publishing:
+Prerequisites: `gh` CLI (authenticated) and `uv` installed.
 
-1. **Create a release branch:**
+### Step 1 — Fill in the `[Unreleased]` section of `CHANGELOG.md`
 
-   ```bash
-   git checkout -b release/vX.Y.Z
-   ```
+Add entries under `## [Unreleased]` as features and fixes land throughout development. Use concise 1-2 line entries categorised under `Added`, `Changed`, `Fixed`, `Documentation`, etc.
 
-2. **Update version numbers:**
+### Step 2 — Run the release script
 
-   ```bash
-   # Update version in src/fontconfig/__init__.py
-   # Version in pyproject.toml is dynamically read from __init__.py
-   ```
+```bash
+bash scripts/release.sh vX.Y.Z
+```
 
-3. **Update CHANGELOG.md:**
+The script validates preconditions (clean tree, `[Unreleased]` section present, no existing branch or tag), then:
 
-   - Change `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`
-   - Or add new version section with changes under Fixed/Added/Changed/Documentation sections
-   - Use concise 1-2 line entries for each change
+- Creates branch `release/vX.Y.Z` from an up-to-date `main`
+- Bumps `__version__` in `src/fontconfig/__init__.py`
+- Moves the `[Unreleased]` content into a new `[X.Y.Z] - YYYY-MM-DD` section (keeping the `[Unreleased]` heading for the next release)
+- Runs `uv sync`
+- Commits, pushes, and opens a GitHub PR titled "Release vX.Y.Z"
 
-4. **Update lock file:**
+### Step 3 — Review and merge the PR
 
-   ```bash
-   uv sync
-   ```
+- Wait for CI checks to pass
+- Get code review approval
+- Merge to `main` — **NEVER commit directly to main**
 
-5. **Commit, push, and create pull request:**
-
-   ```bash
-   git add src/fontconfig/__init__.py CHANGELOG.md uv.lock
-   git commit -m "Bump version to X.Y.Z"
-   git push -u origin release/vX.Y.Z
-
-   # Create PR using gh CLI
-   gh pr create --title "Release vX.Y.Z" --body "Release notes here..."
-   ```
-
-6. **Merge the pull request:**
-
-   - Wait for CI checks to pass
-   - Get code review approval
-   - Merge to main (do NOT commit directly to main)
-
-7. **Create and push git tag (after merge):**
-
-   ```bash
-   git checkout main
-   git pull origin main
-   git tag vX.Y.Z
-   git push origin vX.Y.Z
-   ```
-
-8. **Create GitHub Release:**
-
-   ```bash
-   # Using gh CLI (recommended)
-   gh release create vX.Y.Z --title "Release X.Y.Z" --notes-from-tag
-
-   # Or manually via GitHub web interface:
-   # https://github.com/kyamagu/fontconfig-py/releases/new
-   ```
-
-9. **Publishing to PyPI happens automatically:**
-
-   - The GitHub Actions workflow (`.github/workflows/wheels.yaml`) triggers on release publication
-   - It builds wheels for Linux (x86_64, ARM), macOS (universal2)
-   - Runs pytest to verify builds
-   - Uploads to PyPI using trusted publishing (OIDC)
+Everything after the merge is automatic: the `auto-release` workflow (`.github/workflows/auto-release.yaml`) creates the git tag and GitHub Release, which triggers `wheels.yaml` to build wheels and publish to PyPI.
 
 **Important notes:**
 
-- NEVER commit directly to main - always use a pull request
-- Use `release/vX.Y.Z` branch naming convention for releases
-- Just pushing a tag does NOT trigger PyPI upload
-- A GitHub Release must be created/published to trigger the upload
-- This allows reviewing built wheels and adding release notes before publishing
-- The workflow uses the `release` environment which may require approval
+- Use `release/vX.Y.Z` branch naming (the `auto-release` workflow keys on this prefix)
+- Just pushing a tag does NOT trigger PyPI upload — a GitHub Release must be published
+- The `release` environment in GitHub Actions may require manual approval before PyPI upload

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,9 +301,13 @@ matched = config.font_match(pattern)
 
 Prerequisites: `gh` CLI (authenticated) and `uv` installed.
 
-### Step 1 — Fill in the `[Unreleased]` section of `CHANGELOG.md`
+### Ongoing — Keep `[Unreleased]` up to date
 
-Add entries under `## [Unreleased]` as features and fixes land throughout development. Use concise 1-2 line entries categorised under `Added`, `Changed`, `Fixed`, `Documentation`, etc.
+Every pull request that makes a user-facing change should add an entry under `## [Unreleased]` in `CHANGELOG.md`. Use concise 1-2 line entries categorised under `Added`, `Changed`, `Fixed`, `Documentation`, etc. This is also enforced by the PR checklist in `.github/PULL_REQUEST_TEMPLATE.md`.
+
+### Step 1 — Verify the `[Unreleased]` section before releasing
+
+Confirm that `## [Unreleased]` contains entries covering everything that will ship. The release script will refuse to proceed if the section is empty.
 
 ### Step 2 — Run the release script
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,74 +226,27 @@ feat: Add CharSet support for Unicode character sets
 
 **Note**: This section is for maintainers. Contributors should focus on submitting pull requests for features and fixes.
 
-The project uses a **pull request-based release workflow**:
+Prerequisites: `gh` CLI (authenticated) and `uv` installed.
 
 ### Creating a Release
 
-1. **Create a release branch** from main:
+1. **Keep `CHANGELOG.md` up to date** as development proceeds — add entries under `## [Unreleased]` for each notable change.
+
+2. **Run the release script**:
 
    ```bash
-   git checkout main
-   git pull origin main
-   git checkout -b release/vX.Y.Z
+   bash scripts/release.sh vX.Y.Z
    ```
 
-2. **Update version** in `src/fontconfig/__init__.py`:
+   This creates the `release/vX.Y.Z` branch, bumps the version, updates `CHANGELOG.md`, runs `uv sync`, and opens a PR automatically.
 
-   ```python
-   __version__ = "X.Y.Z"
-   ```
-
-3. **Update CHANGELOG.md**:
-
-   - Change `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`
-   - Or add new version section with changes categorized under Fixed/Added/Changed/Documentation
-   - Use concise 1-2 line entries for each change
-
-4. **Update lock file**:
-
-   ```bash
-   uv sync
-   ```
-
-5. **Create pull request**:
-
-   ```bash
-   git add src/fontconfig/__init__.py CHANGELOG.md uv.lock
-   git commit -m "Bump version to X.Y.Z"
-   git push -u origin release/vX.Y.Z
-   gh pr create --title "Release vX.Y.Z" --body "Release summary..."
-   ```
-
-6. **Merge after approval**:
-
-   - Wait for CI checks to pass
-   - Get code review approval
-   - Merge to main (**NEVER commit directly to main**)
-
-7. **Create git tag and GitHub Release** (after merge):
-
-   ```bash
-   git checkout main
-   git pull origin main
-   git tag vX.Y.Z
-   git push origin vX.Y.Z
-   gh release create vX.Y.Z --title "Release X.Y.Z" --notes-from-tag
-   ```
-
-8. **PyPI publishing happens automatically** when the GitHub Release is created
-
-### Release Branch Naming
-
-- Use `release/vX.Y.Z` format (e.g., `release/v1.0.1`)
-- This ensures consistency and clarity
+3. **Review and merge the PR** — wait for CI, get approval, then merge to `main`. Everything after is automatic: the `auto-release` workflow creates the git tag and GitHub Release, which triggers wheel builds and PyPI publishing.
 
 ### Important Notes
 
-- NEVER commit version bumps directly to main
-- Always use a pull request for releases
-- The GitHub Actions workflow automatically publishes to PyPI when a release is created
-- See [CLAUDE.md](CLAUDE.md) for detailed technical documentation
+- NEVER commit directly to main — always use a pull request
+- Use `release/vX.Y.Z` branch naming (the automation keys on this prefix)
+- See [CLAUDE.md](CLAUDE.md) for full technical documentation
 
 ## Reporting Issues
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -85,6 +85,18 @@ if ! grep -q "^## \[Unreleased\]" CHANGELOG.md; then
     die "CHANGELOG.md has no '## [Unreleased]' section. Add one before releasing."
 fi
 
+# [Unreleased] section has content
+UNRELEASED_BODY=$(python3 -c "
+import re
+with open('CHANGELOG.md') as f:
+    content = f.read()
+m = re.search(r'## \[Unreleased\][^\n]*\n(.*?)(?=^## \[)', content, re.DOTALL | re.MULTILINE)
+print(m.group(1).strip() if m else '')
+")
+if [[ -z "$UNRELEASED_BODY" ]]; then
+    die "The [Unreleased] section in CHANGELOG.md is empty. Add entries describing what changed before releasing."
+fi
+
 # Version heading does not already exist
 if grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
     die "CHANGELOG.md already has a section for [${VERSION}]."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Release preparation script for fontconfig-py.
+#
+# Usage:
+#   scripts/release.sh <version>
+#
+# Example:
+#   scripts/release.sh 1.0.2
+#   scripts/release.sh v1.0.2
+#
+# Prerequisites:
+#   - gh CLI (https://cli.github.com/) installed and authenticated
+#   - uv installed (https://docs.astral.sh/uv/)
+#   - Git remote "origin" pointing to the GitHub repo
+#
+# The script:
+#   1. Validates preconditions (clean tree, [Unreleased] in CHANGELOG, no existing branch)
+#   2. Creates branch release/vX.Y.Z from an up-to-date main
+#   3. Bumps __version__ in src/fontconfig/__init__.py
+#   4. Moves CHANGELOG [Unreleased] content into a new versioned section (keeps [Unreleased] heading)
+#   5. Runs uv sync to update the lock file
+#   6. Commits, pushes, and opens a GitHub PR
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+usage() {
+    echo "Usage: $(basename "$0") <version>"
+    echo "  version  Semver string, e.g. 1.0.2 or v1.0.2"
+}
+
+# ---------------------------------------------------------------------------
+# Parse and validate version argument
+# ---------------------------------------------------------------------------
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+fi
+
+VERSION="${1#v}"  # strip leading 'v' if present
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    die "Invalid version '${VERSION}'. Expected format: X.Y.Z"
+fi
+
+BRANCH="release/v${VERSION}"
+TAG="v${VERSION}"
+TODAY=$(date +%Y-%m-%d)
+
+# ---------------------------------------------------------------------------
+# Precondition checks (before touching anything)
+# ---------------------------------------------------------------------------
+
+echo "Checking prerequisites..."
+
+# gh CLI available and authenticated
+if ! command -v gh &>/dev/null; then
+    die "'gh' CLI is not installed. See https://cli.github.com/"
+fi
+if ! gh auth status &>/dev/null; then
+    die "'gh' is not authenticated. Run: gh auth login"
+fi
+
+# uv available
+if ! command -v uv &>/dev/null; then
+    die "'uv' is not installed. See https://docs.astral.sh/uv/"
+fi
+
+# Clean working tree
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    die "Working tree has uncommitted changes. Commit or stash them first."
+fi
+
+# CHANGELOG has [Unreleased] section
+if ! grep -q "^## \[Unreleased\]" CHANGELOG.md; then
+    die "CHANGELOG.md has no '## [Unreleased]' section. Add one before releasing."
+fi
+
+# Version heading does not already exist
+if grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+    die "CHANGELOG.md already has a section for [${VERSION}]."
+fi
+
+# Branch does not already exist locally
+if git rev-parse --verify "$BRANCH" &>/dev/null; then
+    die "Branch '${BRANCH}' already exists locally."
+fi
+
+# Branch does not already exist on remote
+if git ls-remote --exit-code origin "refs/heads/${BRANCH}" &>/dev/null; then
+    die "Branch '${BRANCH}' already exists on remote."
+fi
+
+# Tag does not already exist
+if git ls-remote --exit-code origin "refs/tags/${TAG}" &>/dev/null; then
+    die "Tag '${TAG}' already exists on remote."
+fi
+
+echo "All checks passed."
+
+# ---------------------------------------------------------------------------
+# Create release branch
+# ---------------------------------------------------------------------------
+
+echo "Switching to main and pulling latest..."
+git checkout main
+git pull origin main
+
+echo "Creating branch ${BRANCH}..."
+git checkout -b "$BRANCH"
+
+# ---------------------------------------------------------------------------
+# Bump version in __init__.py (use Python for cross-platform safety)
+# ---------------------------------------------------------------------------
+
+echo "Bumping version to ${VERSION}..."
+python3 - "$VERSION" <<'PYEOF'
+import re, sys
+
+version = sys.argv[1]
+path = "src/fontconfig/__init__.py"
+
+with open(path) as f:
+    content = f.read()
+
+new_content = re.sub(
+    r'__version__ = "[^"]+"',
+    f'__version__ = "{version}"',
+    content,
+    count=1,
+)
+
+if new_content == content:
+    print(f"Warning: __version__ pattern not found in {path}", file=sys.stderr)
+    sys.exit(1)
+
+with open(path, "w") as f:
+    f.write(new_content)
+
+print(f"  {path}: set __version__ = \"{version}\"")
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Update CHANGELOG.md (use Python for cross-platform safety)
+# ---------------------------------------------------------------------------
+
+echo "Updating CHANGELOG.md..."
+python3 - "$VERSION" "$TODAY" <<'PYEOF'
+import re, sys
+
+version, today = sys.argv[1], sys.argv[2]
+path = "CHANGELOG.md"
+
+with open(path) as f:
+    content = f.read()
+
+# Match the [Unreleased] block: heading + optional body up to the next ## heading
+pattern = re.compile(
+    r"(## \[Unreleased\][^\n]*\n)"   # group 1: the heading line
+    r"(.*?)"                          # group 2: body (may be empty)
+    r"(?=^## \[)",                    # lookahead: next version heading
+    re.DOTALL | re.MULTILINE,
+)
+
+m = pattern.search(content)
+if not m:
+    print("Error: could not locate [Unreleased] block in CHANGELOG.md", file=sys.stderr)
+    sys.exit(1)
+
+unreleased_heading = m.group(1)  # "## [Unreleased]\n"
+unreleased_body = m.group(2)     # content between headings
+
+# Build replacement: keep [Unreleased] (empty), insert new versioned section
+versioned_section = f"## [{version}] - {today}\n{unreleased_body}"
+replacement = unreleased_heading + "\n" + versioned_section
+
+new_content = content[: m.start()] + replacement + content[m.end() :]
+
+with open(path, "w") as f:
+    f.write(new_content)
+
+print(f"  CHANGELOG.md: inserted ## [{version}] - {today}")
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Update lock file
+# ---------------------------------------------------------------------------
+
+echo "Running uv sync..."
+uv sync
+
+# ---------------------------------------------------------------------------
+# Commit, push, open PR
+# ---------------------------------------------------------------------------
+
+echo "Committing changes..."
+git add src/fontconfig/__init__.py CHANGELOG.md uv.lock
+git commit -m "Bump version to ${VERSION}"
+
+echo "Pushing branch..."
+git push -u origin "$BRANCH"
+
+echo "Creating pull request..."
+gh pr create \
+    --title "Release v${VERSION}" \
+    --body "$(cat <<EOF
+## Release v${VERSION}
+
+See [CHANGELOG.md](CHANGELOG.md) for details.
+
+## Checklist
+
+- [ ] Version bumped in \`src/fontconfig/__init__.py\`
+- [ ] CHANGELOG updated with release date
+- [ ] CI checks pass
+- [ ] Code review approved
+
+After merging, the tag and GitHub Release are created automatically by the \`auto-release\` workflow, which then triggers the wheel build and PyPI publish.
+EOF
+)"
+
+echo ""
+echo "Done. Release PR for v${VERSION} is open."
+echo "After it is merged, the rest of the release happens automatically."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -90,7 +90,7 @@ UNRELEASED_BODY=$(python3 -c "
 import re
 with open('CHANGELOG.md') as f:
     content = f.read()
-m = re.search(r'## \[Unreleased\][^\n]*\n(.*?)(?=^## \[)', content, re.DOTALL | re.MULTILINE)
+m = re.search(r'## \[Unreleased\][^\n]*\n(.*?)(?=^## \[|\Z)', content, re.DOTALL | re.MULTILINE)
 print(m.group(1).strip() if m else '')
 ")
 if [[ -z "$UNRELEASED_BODY" ]]; then
@@ -179,7 +179,7 @@ with open(path) as f:
 pattern = re.compile(
     r"(## \[Unreleased\][^\n]*\n)"   # group 1: the heading line
     r"(.*?)"                          # group 2: body (may be empty)
-    r"(?=^## \[)",                    # lookahead: next version heading
+    r"(?=^## \[|\Z)",                  # lookahead: next version heading or EOF
     re.DOTALL | re.MULTILINE,
 )
 


### PR DESCRIPTION
## Summary

- Add `scripts/release.sh` to automate the release preparation workflow (create branch, bump version, update CHANGELOG, open PR)
- Add `.github/workflows/auto-release.yaml` to automatically create the git tag and GitHub Release when a `release/v*` branch is merged to `main`
- Add `/release` Claude Code skill (`.claude/commands/release.md`) for AI-assisted release orchestration
- Update `CLAUDE.md` and `CONTRIBUTING.md` release docs to reflect the new workflow

## Fixes included

- `release.sh` now fails early if the `[Unreleased]` CHANGELOG section is empty (matches documented behaviour)
- `CHANGELOG.md`: add `[Unreleased]` section with entry for this PR
- `.markdownlint.json`: enable `allow_different_nesting` so repeated sub-headings across CHANGELOG versions don't trigger MD024 warnings

## Test plan

- [ ] Review `scripts/release.sh` logic (precondition checks, version bump, CHANGELOG update, PR creation)
- [ ] Review `.github/workflows/auto-release.yaml` (trigger condition, tag creation, release notes extraction)
- [ ] Verify `release.sh` exits non-zero when `[Unreleased]` section is empty
- [ ] Confirm markdownlint no longer warns on CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)