### PR TITLE
Replace manual [Unreleased] CHANGELOG with release-drafter

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -4,17 +4,25 @@ Execute the release workflow for fontconfig-py. Follow every step below in order
 
 Read `src/fontconfig/__init__.py` and extract `__version__`.
 
-## Step 2 — Validate CHANGELOG
+## Step 2 — Verify the draft-next release
 
-Read `CHANGELOG.md`. Find the `## [Unreleased]` section (everything between that heading and the next `## [` heading). If it contains no non-whitespace content, stop and tell the user:
+Run:
 
-> The `[Unreleased]` section in CHANGELOG.md is empty. Please add content describing what changed before running a release.
+```bash
+gh release view "draft-next" --json body --jq '.body'
+```
+
+If the command fails or the body is empty, stop and tell the user:
+
+> No `draft-next` draft release found. Merge at least one labeled PR so release-drafter can generate notes, then try again. You can also create it manually at <https://github.com/CyberAgent/fontconfig-py/releases/new>
+
+If the draft exists, show the user a brief summary of its content and ask them to confirm it looks complete before proceeding.
 
 ## Step 3 — Determine the target version
 
 **If `$ARGUMENTS` is provided:** trim any surrounding whitespace. If it does not match `(?:v)?\d+\.\d+\.\d+`, tell the user the format must be `X.Y.Z` or `vX.Y.Z` and stop.
 
-**If `$ARGUMENTS` is empty:** infer the next version from the `[Unreleased]` section headings and the current version:
+**If `$ARGUMENTS` is empty:** infer the next version from the draft-next body headings and the current version:
 
 - Any `### Breaking Changes` heading → **major** bump (`X+1.0.0`)
 - Any `### Added` heading (no breaking changes) → **minor** bump (`x.Y+1.0`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,12 +46,13 @@ Fixes # (issue)
 - [ ] Linting passes (`uvx ruff check .`)
 - [ ] Type checking passes (`uv run mypy src/ tests/`)
 - [ ] Documentation updated (if applicable)
-- [ ] CHANGELOG.md updated following [Keep a Changelog][keepachangelog]
-      format (for user-facing changes)
+- [ ] PR has an appropriate label for release notes
+      (`feature`/`enhancement`, `bug`, `breaking-change`, `changed`, `documentation`,
+      `infrastructure`, `dependencies`, `technical`, or `skip-changelog`
+      if no user-facing change)
 - [ ] Follows [conventional commit][conventionalcommits] message format
 - [ ] Includes tests for new functionality (if applicable)
 
-[keepachangelog]: https://keepachangelog.com/
 [conventionalcommits]: https://www.conventionalcommits.org/
 
 ## Additional Notes

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,22 @@
+name-template: 'Draft Release Notes'
+tag-template: 'draft-next'
+categories:
+  - title: '### Breaking Changes'
+    labels: ['breaking-change']
+  - title: '### Added'
+    labels: ['feature', 'enhancement']
+  - title: '### Changed'
+    labels: ['changed']
+  - title: '### Fixed'
+    labels: ['bug']
+  - title: '### Documentation'
+    labels: ['documentation']
+  - title: '### Infrastructure'
+    labels: ['infrastructure', 'dependencies']
+  - title: '### Technical'
+    labels: ['technical']
+exclude-labels: ['skip-changelog']
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
+template: |
+  $CHANGES

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -110,3 +110,13 @@ jobs:
             --title "Release ${{ steps.version.outputs.version }}" \
             --notes-file "${{ steps.changelog.outputs.notes_file }}"
           echo "GitHub Release created for ${{ steps.version.outputs.tag }}"
+
+      - name: Delete stale draft-next release
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "draft-next" &>/dev/null; then
+            gh release delete "draft-next" --yes
+            echo "Deleted stale draft-next release"
+          fi

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,8 +3,6 @@ name: Release Drafter
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ Every pull request should have an appropriate label so release-drafter can categ
 | Label | CHANGELOG section |
 | --- | --- |
 | `breaking-change` | Breaking Changes |
-| `feature` | Added |
+| `feature`, `enhancement` | Added |
 | `changed` | Changed |
 | `bug` | Fixed |
 | `documentation` | Documentation |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,13 +301,26 @@ matched = config.font_match(pattern)
 
 Prerequisites: `gh` CLI (authenticated) and `uv` installed.
 
-### Ongoing — Keep `[Unreleased]` up to date
+### Ongoing — Label PRs for release notes
 
-Every pull request that makes a user-facing change should add an entry under `## [Unreleased]` in `CHANGELOG.md`. Use concise 1-2 line entries categorised under `Added`, `Changed`, `Fixed`, `Documentation`, etc. This is also enforced by the PR checklist in `.github/PULL_REQUEST_TEMPLATE.md`.
+Every pull request should have an appropriate label so release-drafter can categorise it automatically. Available labels (defined in `.github/release-drafter.yml`):
 
-### Step 1 — Verify the `[Unreleased]` section before releasing
+| Label | CHANGELOG section |
+| --- | --- |
+| `breaking-change` | Breaking Changes |
+| `feature` | Added |
+| `changed` | Changed |
+| `bug` | Fixed |
+| `documentation` | Documentation |
+| `infrastructure`, `dependencies` | Infrastructure |
+| `technical` | Technical |
+| `skip-changelog` | (excluded — use for release PRs and internal changes) |
 
-Confirm that `## [Unreleased]` contains entries covering everything that will ship. The release script will refuse to proceed if the section is empty.
+Release-drafter accumulates entries from merged PRs into a rolling draft release tagged `draft-next` on GitHub.
+
+### Step 1 — Verify the draft release before releasing
+
+Check that the `draft-next` draft at `https://github.com/CyberAgent/fontconfig-py/releases` covers everything that will ship. Edit it directly on GitHub if any entry needs rewording before the release script runs.
 
 ### Step 2 — Run the release script
 
@@ -315,13 +328,13 @@ Confirm that `## [Unreleased]` contains entries covering everything that will sh
 bash scripts/release.sh vX.Y.Z
 ```
 
-The script validates preconditions (clean tree, `[Unreleased]` section present, no existing branch or tag), then:
+The script validates preconditions (clean tree, `draft-next` draft exists, no existing branch or tag), then:
 
 - Creates branch `release/vX.Y.Z` from an up-to-date `main`
 - Bumps `__version__` in `src/fontconfig/__init__.py`
-- Moves the `[Unreleased]` content into a new `[X.Y.Z] - YYYY-MM-DD` section (keeping the `[Unreleased]` heading for the next release)
+- Writes the `draft-next` content into a new `[X.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md`
 - Runs `uv sync`
-- Commits, pushes, and opens a GitHub PR titled "Release vX.Y.Z"
+- Commits, pushes, and opens a GitHub PR titled "Release vX.Y.Z" (labeled `skip-changelog`)
 
 ### Step 3 — Review and merge the PR
 
@@ -329,7 +342,7 @@ The script validates preconditions (clean tree, `[Unreleased]` section present, 
 - Get code review approval
 - Merge to `main` — **NEVER commit directly to main**
 
-Everything after the merge is automatic: the `auto-release` workflow (`.github/workflows/auto-release.yaml`) creates the git tag and GitHub Release, which triggers `wheels.yaml` to build wheels and publish to PyPI.
+Everything after the merge is automatic: the `auto-release` workflow (`.github/workflows/auto-release.yaml`) creates the git tag and GitHub Release from `CHANGELOG.md`, then deletes the stale `draft-next` draft. This triggers `wheels.yaml` to build wheels and publish to PyPI.
 
 **Important notes:**
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,8 +12,6 @@
 #   - gh CLI (https://cli.github.com/) installed and authenticated
 #   - uv installed (https://docs.astral.sh/uv/)
 #   - Git remote "origin" pointing to the GitHub repo
-#
-# Prerequisites:
 #   - A 'draft-next' draft release created by the release-drafter workflow
 #
 # The script:
@@ -105,10 +103,15 @@ fi
 
 # draft-next release must exist and contain at least one real entry
 echo "Fetching release notes from draft-next draft..."
-DRAFT_BODY=$(gh release view "draft-next" --json body --jq '.body' 2>/dev/null || echo "")
+_DRAFT_STDERR=$(mktemp)
+if ! DRAFT_BODY=$(gh release view "draft-next" --json body --jq '.body' 2>"$_DRAFT_STDERR"); then
+    _DRAFT_ERROR=$(cat "$_DRAFT_STDERR"); rm -f "$_DRAFT_STDERR"
+    die "Failed to read 'draft-next' draft release: ${_DRAFT_ERROR}"
+fi
+rm -f "$_DRAFT_STDERR"
 DRAFT_BODY_TRIMMED=$(printf '%s' "$DRAFT_BODY" | tr -d '[:space:]')
 if [[ -z "$DRAFT_BODY_TRIMMED" ]]; then
-    die "No 'draft-next' draft release found. Merge a PR first so release-drafter can generate notes, then try again."
+    die "'draft-next' draft release body is empty. Merge a PR with a release label first so release-drafter can generate notes, then try again."
 fi
 
 echo "All checks passed."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,13 +13,16 @@
 #   - uv installed (https://docs.astral.sh/uv/)
 #   - Git remote "origin" pointing to the GitHub repo
 #
+# Prerequisites:
+#   - A 'draft-next' draft release created by the release-drafter workflow
+#
 # The script:
-#   1. Validates preconditions (clean tree, [Unreleased] in CHANGELOG, no existing branch)
+#   1. Validates preconditions (clean tree, draft-next release exists, no existing branch)
 #   2. Creates branch release/vX.Y.Z from an up-to-date main
 #   3. Bumps __version__ in src/fontconfig/__init__.py
-#   4. Moves CHANGELOG [Unreleased] content into a new versioned section (keeps [Unreleased] heading)
+#   4. Writes draft-next release notes into a new versioned CHANGELOG section
 #   5. Runs uv sync to update the lock file
-#   6. Commits, pushes, and opens a GitHub PR
+#   6. Commits, pushes, and opens a GitHub PR (labeled skip-changelog)
 
 set -euo pipefail
 
@@ -80,23 +83,6 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
     die "Working tree has uncommitted changes. Commit or stash them first."
 fi
 
-# CHANGELOG has [Unreleased] section
-if ! grep -q "^## \[Unreleased\]" CHANGELOG.md; then
-    die "CHANGELOG.md has no '## [Unreleased]' section. Add one before releasing."
-fi
-
-# [Unreleased] section has content
-UNRELEASED_BODY=$(python3 -c "
-import re
-with open('CHANGELOG.md') as f:
-    content = f.read()
-m = re.search(r'## \[Unreleased\][^\n]*\n(.*?)(?=^## \[|\Z)', content, re.DOTALL | re.MULTILINE)
-print(m.group(1).strip() if m else '')
-")
-if [[ -z "$UNRELEASED_BODY" ]]; then
-    die "The [Unreleased] section in CHANGELOG.md is empty. Add entries describing what changed before releasing."
-fi
-
 # Version heading does not already exist
 if grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
     die "CHANGELOG.md already has a section for [${VERSION}]."
@@ -115,6 +101,14 @@ fi
 # Tag does not already exist
 if git ls-remote --exit-code origin "refs/tags/${TAG}" &>/dev/null; then
     die "Tag '${TAG}' already exists on remote."
+fi
+
+# draft-next release must exist and contain at least one real entry
+echo "Fetching release notes from draft-next draft..."
+DRAFT_BODY=$(gh release view "draft-next" --json body --jq '.body' 2>/dev/null || echo "")
+DRAFT_BODY_TRIMMED=$(printf '%s' "$DRAFT_BODY" | tr -d '[:space:]')
+if [[ -z "$DRAFT_BODY_TRIMMED" ]]; then
+    die "No 'draft-next' draft release found. Merge a PR first so release-drafter can generate notes, then try again."
 fi
 
 echo "All checks passed."
@@ -162,39 +156,34 @@ print(f"  {path}: set __version__ = \"{version}\"")
 PYEOF
 
 # ---------------------------------------------------------------------------
-# Update CHANGELOG.md (use Python for cross-platform safety)
+# Update CHANGELOG.md from draft-next release notes (use Python for cross-platform safety)
 # ---------------------------------------------------------------------------
 
-echo "Updating CHANGELOG.md..."
-python3 - "$VERSION" "$TODAY" <<'PYEOF'
+echo "Updating CHANGELOG.md from draft release notes..."
+python3 - "$VERSION" "$TODAY" "$DRAFT_BODY" <<'PYEOF'
 import re, sys
 
-version, today = sys.argv[1], sys.argv[2]
+version, today, draft_body = sys.argv[1], sys.argv[2], sys.argv[3]
 path = "CHANGELOG.md"
 
 with open(path) as f:
     content = f.read()
 
-# Match the [Unreleased] block: heading + optional body up to the next ## heading
+# Match the entire [Unreleased] block: heading + body up to the next ## heading
 pattern = re.compile(
-    r"(## \[Unreleased\][^\n]*\n)"   # group 1: the heading line
-    r"(.*?)"                          # group 2: body (may be empty)
-    r"(?=^## \[|\Z)",                  # lookahead: next version heading or EOF
+    r"(## \[Unreleased\][^\n]*\n)"  # group 1: heading line
+    r"(.*?)"                         # group 2: existing body (cleared)
+    r"(?=^## \[|\Z)",                # lookahead: next versioned heading or EOF
     re.DOTALL | re.MULTILINE,
 )
-
 m = pattern.search(content)
 if not m:
     print("Error: could not locate [Unreleased] block in CHANGELOG.md", file=sys.stderr)
     sys.exit(1)
 
-unreleased_heading = m.group(1)  # "## [Unreleased]\n"
-unreleased_body = m.group(2)     # content between headings
-
-# Build replacement: keep [Unreleased] (empty), insert new versioned section
-versioned_section = f"## [{version}] - {today}\n{unreleased_body}"
-replacement = unreleased_heading + "\n" + versioned_section
-
+# Replace: keep [Unreleased] heading (empty), then insert new versioned section
+versioned_section = f"## [{version}] - {today}\n\n{draft_body.strip()}\n\n"
+replacement = m.group(1) + "\n" + versioned_section
 new_content = content[: m.start()] + replacement + content[m.end() :]
 
 with open(path, "w") as f:
@@ -224,6 +213,7 @@ git push -u origin "$BRANCH"
 echo "Creating pull request..."
 gh pr create \
     --title "Release v${VERSION}" \
+    --label "skip-changelog" \
     --body "$(cat <<EOF
 ## Release v${VERSION}
 


### PR DESCRIPTION
## Summary

- Add release-drafter workflow that auto-populates a `draft-next` draft release from PR titles and labels on every merge to main — contributors no longer need to update `CHANGELOG.md` in each PR
- `scripts/release.sh` now reads the `draft-next` draft body and writes it as the versioned CHANGELOG section (clearing any stale `[Unreleased]` content) instead of moving `[Unreleased]`
- `auto-release.yaml` deletes the stale `draft-next` draft after the final GitHub Release is created
- Release PRs are labeled `skip-changelog` automatically to prevent them feeding back into the next draft cycle
- PR template updated: CHANGELOG checklist item replaced with a label checklist

## Test plan

- [ ] Merge a PR with a `feature` or `bug` label → confirm `draft-next` draft appears on the Releases page
- [ ] Run `bash scripts/release.sh X.Y.Z` → confirm it reads from `draft-next`, writes the versioned section into `CHANGELOG.md`, clears `[Unreleased]` body, and creates a PR with `skip-changelog` label
- [ ] Confirm `release.sh` fails when no `draft-next` draft exists (or draft body is empty)
- [ ] Merge the release PR → confirm `auto-release.yaml` creates the tag + GitHub Release and deletes `draft-next`
- [ ] Merge a PR with no label or `skip-changelog` label → confirm the draft is not updated with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)