### PR TITLE
Fix uv sync on macOS by passing pkg-config flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,9 +283,13 @@ matched = config.font_match(pattern)
 
 - Ensure git submodules are initialized: `git submodule update --init --recursive`
 - Check system dependencies are installed (see `build_third_party.sh`)
-- On macOS, ensure Xcode command line tools are installed. Also, set the following environment variables in the local environment:
-  - `CC=clang`
-  - `CFLAGS="-I/opt/homebrew/include -L/opt/homebrew/lib"`
+- On macOS, ensure Xcode command line tools are installed. The compiler cannot find fontconfig/freetype headers unless the flags are passed explicitly. Use `pkg-config` (installed with `brew install pkg-config`):
+
+  ```bash
+  CFLAGS=$(pkg-config --cflags fontconfig freetype2) \
+  LDFLAGS=$(pkg-config --libs fontconfig freetype2) \
+  uv sync
+  ```
 
 **Test failures on "family=Arial":**
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -200,7 +200,16 @@ PYEOF
 # ---------------------------------------------------------------------------
 
 echo "Running uv sync..."
-uv sync
+# On macOS with Homebrew, the compiler cannot find fontconfig/freetype headers
+# unless the flags are passed explicitly.  Use pkg-config when available so the
+# command is portable and does not hard-code Homebrew paths.
+if command -v pkg-config &>/dev/null && pkg-config --exists fontconfig freetype2 2>/dev/null; then
+    CFLAGS="$(pkg-config --cflags fontconfig freetype2) ${CFLAGS:-}" \
+    LDFLAGS="$(pkg-config --libs fontconfig freetype2) ${LDFLAGS:-}" \
+    uv sync
+else
+    uv sync
+fi
 
 # ---------------------------------------------------------------------------
 # Commit, push, open PR

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -208,6 +208,11 @@ if command -v pkg-config &>/dev/null && pkg-config --exists fontconfig freetype2
     LDFLAGS="$(pkg-config --libs fontconfig freetype2) ${LDFLAGS:-}" \
     uv sync
 else
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "Warning: pkg-config metadata for fontconfig/freetype2 not found." >&2
+        echo "  uv sync may fail. If it does, install the missing packages with:" >&2
+        echo "    brew install pkg-config fontconfig freetype" >&2
+    fi
     uv sync
 fi
 


### PR DESCRIPTION
## Summary

- `scripts/release.sh`: before calling `uv sync`, detect `pkg-config` and pass `CFLAGS`/`LDFLAGS` derived from `pkg-config --cflags/--libs fontconfig freetype2` so the build succeeds on macOS with Homebrew without any manual env-var setup.
- `CLAUDE.md`: update the macOS troubleshooting hint to use the same `pkg-config` form instead of hardcoded `/opt/homebrew` paths.

## Test plan

- [ ] Run `bash scripts/release.sh` on macOS with Homebrew fontconfig installed — `uv sync` should complete without header-not-found errors.
- [ ] Confirm the script still works on Linux (where `pkg-config` is available and fontconfig headers are in the standard path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)