### PR TITLE
Fix macOS universal2 wheel build broken by json-c on runner image

### DIFF
--- a/scripts/build_third_party.sh
+++ b/scripts/build_third_party.sh
@@ -61,8 +61,12 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     # Set Homebrew-specific directories for fontconfig by default on macOS
     export FC_SYSCONFDIR="$(brew --prefix)/etc"
     export FC_LOCALSTATEDIR="$(brew --prefix)/var"
-    # Make sure conflicting packages are not installed
-    brew uninstall --ignore-dependencies -f fontconfig freetype
+    # Make sure conflicting packages are not installed.
+    # json-c is uninstalled too: when present, fontconfig's configure detects it
+    # and builds test/test-conf, but Homebrew ships json-c arm64-only, so the
+    # x86_64 slice of the universal2 build fails to link. We only need the
+    # static library, not fontconfig's test suite.
+    brew uninstall --ignore-dependencies -f fontconfig freetype json-c
     brew install gperftools gettext automake libtool
     prepare_macos_dirs
 elif command -v dnf &> /dev/null; then


### PR DESCRIPTION
## Problem

All wheel builds are failing on `macOS-latest` (this blocks `main`, not just the dependabot PR that surfaced it in #99). The failure is a linker error while building fontconfig in `scripts/build_third_party.sh`:

```
checking for JSONC... yes
...
ld: warning: ignoring file '/opt/homebrew/Cellar/json-c/0.19/lib/libjson-c.dylib':
    found architecture 'arm64', required architecture 'x86_64'
Undefined symbols for architecture x86_64:
  "_json_object_array_get_idx", referenced from: _run_test in test_conf-test-conf.o
  ...
make[3]: *** [test-conf] Error 1
##[error]cibuildwheel: Command bash ./scripts/build_third_party.sh failed with code 2.
```

## Root cause

Between the last green run (July 14) and now, the `macOS-latest` runner image was updated and now ships Homebrew **`json-c` 0.19**.

1. fontconfig's `configure` auto-detects json-c via pkg-config (`checking for JSONC... yes`) and consequently compiles the `test/test-conf` program, which links against json-c.
2. Wheels are built **`universal2`** (`-arch x86_64 -arch arm64`), but Homebrew's json-c is **arm64-only**, so the x86_64 slice of `test-conf` fails to link and the whole `make` fails.

The Linux jobs showed `The operation was canceled` — that's just matrix fail-fast, not an independent failure.

## Fix

We only consume the fontconfig **static library**, not its test suite. Uninstall `json-c` on the macOS path — mirroring the existing `fontconfig`/`freetype` uninstall — so `configure` doesn't detect it and skips `test-conf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)